### PR TITLE
WIP:  Add internal wrappers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
 install:
   - source /opt/openfoam222/etc/bashrc
   - make simphony-env
-  - make -j 2 lammps jyu-lb
   - source ~/simphony/bin/activate
+  - make -j 2 kratos numerrin lammps jyu-lb
   - make simphony
   - make simphony-plugins
 script:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@
 # You can set these variables from the command line.
 SIMPHONYENV   ?= ~/simphony
 SIMPHONYVERSION  ?= 0.1.3
+HAVE_NUMERRIN   ?= no
+
+ifeq ($(HAVE_NUMERRIN),yes)
+	TEST_NUMERRIN_COMMAND=(cd src/simphony-numerrin; LD_LIBRARY_PATH=../../lib haas numerrin_wrapper -v)
+else
+	TEST_NUMERRIN_COMMAND=@echo "skip NUMERRIN tests"
+endif
+
 
 .PHONY: clean base apt-openfoam apt-simphony apt-lammps apt-numerrin apt-mayavi fix-pip simphony-env lammps jyu-lb simphony simphony-lammps simphony-numerrin simphony-mayavi simphony-openfoam simphony-jyu-lb test-plugins test-framework
 
@@ -177,7 +185,7 @@ test-plugins:
 	LD_LIBRARY_PATH=./lib/:$LD_LIBRARY_PATH haas simlammps -v
 	haas simphony_mayavi -v
 	(cd src/simphony-openfoam; haas foam_controlwrapper -v)
-	(cd src/simphony-numerrin; LD_LIBRARY_PATH=../../lib haas numerrin_wrapper -v)
+	$(TEST_NUMERRIN_COMMAND)
 	@echo
 	@echo "Tests for the simphony plugins done"
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ clean:
 	rm -Rf src/lammps
 	rm -Rf src/JYU-LB
 	rm -Rf src/simphony-openfoam
+	rm -Rf src/simphony-jyulb
 	rm -rf lib/liblammps.so
 	@echo
 	@echo "Removed temporary folders"
@@ -97,9 +98,9 @@ lammps:
 
 jyu-lb:
 	rm -Rf src/JYU-LB
-	git clone --branch 0.1.0 https://github.com/simphony/JYU-LB.git src/JYU-LB
+	git clone --branch master https://github.com/simphony/JYU-LB.git src/JYU-LB
 	$(MAKE) -C src/JYU-LB -j 2
-	cp src/JYU-LB/bin/jyu_lb_isothermal3D.exe $(SIMPHONYENV)/bin/jyu_lb_isothermal3D.exe
+	cp src/JYU-LB/bin/jyu_lb_isothermal.exe $(SIMPHONYENV)/bin/jyu_lb_isothermal.exe
 	rm -Rf src/JYU-LB
 	@echo
 	@echo "jyu-lb solver installed"
@@ -127,7 +128,10 @@ simphony-openfoam:
 	@echo "Simphony OpenFoam plugin installed"
 
 simphony-jyu-lb:
-	pip install --upgrade git+https://github.com/simphony/simphony-jyulb.git@0.1.1#egg=jyu_engine
+	rm -Rf src/simphony-jyulb
+	git clone --branch 0.1.2 --depth 1 https://github.com/simphony/simphony-jyulb.git src/simphony-jyulb
+	git clone --branch master https://github.com/simphony/JYU-LB.git src/simphony-jyulb/JYU-LB
+	(cd src/simphony-jyulb; python setup.py develop)
 	@echo
 	@echo "Simphony jyu-lb plugin installed"
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ apt-mayavi:
 apt-numerrin:
 	rm -Rf src/simphony-numerrin
 	git clone --branch 0.1.0 https://github.com/simphony/simphony-numerrin.git src/simphony-numerrin
-	cp src/simphony-numerrin/numerrin-interface/libnumerrin4.so lib/.
+	(mkdir -p lib; cp src/simphony-numerrin/numerrin-interface/libnumerrin4.so lib/.)
 	rm -Rf src/simphony-numerrin
 	@echo
 	@echo "Numerrin installed"
@@ -122,7 +122,7 @@ lammps:
 	cp src/lammps/src/lmp_ubuntu_simple $(SIMPHONYENV)/bin/lammps
 	$(MAKE) -C src/lammps/src makeshlib -j 2
 	$(MAKE) -C src/lammps/src ubuntu_simple -f Makefile.shlib -j 2
-	(mkdir lib; cd src/lammps/python; python install.py ../../../lib $(SIMPHONYENV)/lib/python2.7/site-packages/)
+	(mkdir -p lib; cd src/lammps/python; python install.py ../../../lib $(SIMPHONYENV)/lib/python2.7/site-packages/)
 	rm -Rf src/lammps
 	@echo
 	@echo "Lammps solver installed"

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ jyu-lb:
 
 kratos:
 	rm -Rf src/kratos
-	mkdir src/kratos
+	mkdir -p src/kratos
 	wget https://web.cimne.upc.edu/users/croig/data/kratos-simphony.tgz -O src/kratos/kratos.tgz
 	(tar -xzf src/kratos/kratos.tgz -C src/kratos; rm -Rf src/kratos/kratos.tgz)
 	rm -rf $(SIMPHONYENV)/lib/python2.7/site-packages/KratosMultiphysics

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ simphony-lammps:
 	@echo
 	@echo "Simphony lammps plugin installed"
 
-simphony-plugins: simphony-mayavi simphony-openfoam simphony-jyulb simphony-lammps
+simphony-plugins: simphony-numerrin simphony-mayavi simphony-openfoam simphony-jyulb simphony-lammps
 	@echo
 	@echo "Simphony plugins installed"
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ help:
 	@echo "  simphony-lammps   to build and install the simphony-lammps plugin"
 	@echo "  simphony-numerrin to build and install the simphony-numerrin plugin"
 	@echo "  simphony-mayavi   to build and install the simphony-mayavi plugin"
-	@echo "  simphony-openfoam to build and install the simphony-mayavi plugin"
+	@echo "  simphony-openfoam to build and install the simphony-openfoam plugin"
 	@echo "  simphony-jyulb    to build and install the simphony-jyulb plugin"
 	@echo "  simphony-plugins  to build and install all the simphony-plugins"
 	@echo "  test-plugins      run the tests for all the simphony-plugins"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 SIMPHONYENV   ?= ~/simphony
 SIMPHONYVERSION  ?= 0.1.3
 
-.PHONY: clean base apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip simphony-env lammps jyu-lb simphony simphony-lammps simphony-mayavi simphony-openfoam simphony-jyu-lb test-plugins test-framework
+.PHONY: clean base apt-openfoam apt-simphony apt-lammps apt-numerrin apt-mayavi fix-pip simphony-env lammps jyu-lb simphony simphony-lammps simphony-numerrin simphony-mayavi simphony-openfoam simphony-jyu-lb test-plugins test-framework
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -13,6 +13,7 @@ help:
 	@echo "  apt-openfoam      to install openfoam 2.2.2 (requires sudo)"
 	@echo "  apt-simphony      to install building depedencies for the simphony library (requires sudo)"
 	@echo "  apt-lammps        to install building depedencies for the lammps solver (requires sudo)"
+	@echo "  apt-numerrin      to install numerrin (requires sudo)"
 	@echo "  apt-mayavi        to install building depedencies for the mayavi (requires sudo)"
 	@echo "  fix-pip           to update the version of pip and virtual evn (requires sudo)"
 	@echo "  simphony-env      to create a simphony virtualenv"
@@ -20,6 +21,7 @@ help:
 	@echo "  jyu-lb            to build and install the JYU-LB solver"
 	@echo "  simphony          to build and install the simphony library"
 	@echo "  simphony-lammps   to build and install the simphony-lammps plugin"
+	@echo "  simphony-numerrin to build and install the simphony-numerrin plugin"
 	@echo "  simphony-mayavi   to build and install the simphony-mayavi plugin"
 	@echo "  simphony-openfoam to build and install the simphony-mayavi plugin"
 	@echo "  simphony-jyu-lb   to build and install the simphony-jyu-lb plugin"
@@ -33,7 +35,10 @@ clean:
 	rm -Rf src/JYU-LB
 	rm -Rf src/simphony-openfoam
 	rm -Rf src/simphony-jyulb
+	rm -Rf src/simphony-numerrin
 	rm -rf lib/liblammps.so
+	rm -rf lib/libnumerrin4.so
+	rm -rf lib/numerrin.so
 	@echo
 	@echo "Removed temporary folders"
 
@@ -67,6 +72,15 @@ apt-mayavi:
 	apt-get install python-vtk python-qt4 python-qt4-dev python-sip python-qt4-gl libqt4-scripttools python-imaging
 	@echo
 	@echo "Build dependencies for mayavi installed"
+
+apt-numerrin:
+	rm -Rf src/simphony-numerrin
+	git clone --branch 0.1.0 https://github.com/simphony/simphony-numerrin.git src/simphony-numerrin
+	cp src/simphony-numerrin/numerrin-interface/libnumerrin4.so lib/.
+	rm -Rf src/simphony-numerrin
+	@echo
+	@echo "Numerrin installed"
+	@echo "(Ensure that environment variable PYNUMERRIN_LICENSE points to license file)"
 
 fix-pip:
 	wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
@@ -117,6 +131,14 @@ simphony-mayavi:
 	@echo
 	@echo "Simphony Mayavi plugin installed"
 
+simphony-numerrin:
+	rm -Rf src/simphony-numerrin
+	git clone --branch 0.1.0 https://github.com/simphony/simphony-numerrin.git src/simphony-numerrin
+	cp src/simphony-numerrin/numerrin-interface/numerrin.so $(SIMPHONYENV)/lib/python2.7/site-packages/
+	(cd src/simphony-numerrin; python setup.py develop)
+	@echo
+	@echo "Simphony Numerrin plugin installed"
+
 simphony-openfoam:
 	pip install --upgrade svn+https://svn.code.sf.net/p/openfoam-extend/svn/trunk/Breeder/other/scripting/PyFoam#egg=PyFoam
 	rm -Rf src/simphony-openfoam
@@ -155,6 +177,7 @@ test-plugins:
 	LD_LIBRARY_PATH=./lib/:$LD_LIBRARY_PATH haas simlammps -v
 	haas simphony_mayavi -v
 	(cd src/simphony-openfoam; haas foam_controlwrapper -v)
+	(cd src/simphony-numerrin; LD_LIBRARY_PATH=../../lib haas numerrin_wrapper -v)
 	@echo
 	@echo "Tests for the simphony plugins done"
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ clean:
 	rm -Rf src/lammps
 	rm -Rf src/JYU-LB
 	rm -Rf src/simphony-openfoam
+	rm -rf lib/liblammps.so
 	@echo
 	@echo "Removed temporary folders"
 
@@ -89,7 +90,7 @@ lammps:
 	cp src/lammps/src/lmp_ubuntu_simple $(SIMPHONYENV)/bin/lammps
 	$(MAKE) -C src/lammps/src makeshlib -j 2
 	$(MAKE) -C src/lammps/src ubuntu_simple -f Makefile.shlib -j 2
-	(cd src/lammps/python; python install.py ../../../lib $(SIMPHONYENV)/lib/python2.7/site-packages/)
+	(mkdir lib; cd src/lammps/python; python install.py ../../../lib $(SIMPHONYENV)/lib/python2.7/site-packages/)
 	rm -Rf src/lammps
 	@echo
 	@echo "Lammps solver installed"

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ lammps:
 	git clone --branch r12824 --depth 1 git://git.lammps.org/lammps-ro.git src/lammps
 	$(MAKE) -C src/lammps/src ubuntu_simple -j 2
 	cp src/lammps/src/lmp_ubuntu_simple $(SIMPHONYENV)/bin/lammps
+	$(MAKE) -C src/lammps/src makeshlib -j 2
+	$(MAKE) -C src/lammps/src ubuntu_simple -f Makefile.shlib -j 2
+	(cd src/lammps/python; python install.py ../../../lib $(SIMPHONYENV)/lib/python2.7/site-packages/)
 	rm -Rf src/lammps
 	@echo
 	@echo "Lammps solver installed"
@@ -128,7 +131,7 @@ simphony-jyu-lb:
 	@echo "Simphony jyu-lb plugin installed"
 
 simphony-lammps:
-	pip install --upgrade git+https://github.com/simphony/simphony-lammps-md.git@0.1.2#egg=simlammps
+	pip install --upgrade git+https://github.com/simphony/simphony-lammps-md.git@0.1.3#egg=simlammps
 	@echo
 	@echo "Simphony lammps plugin installed"
 
@@ -144,7 +147,7 @@ test-plugins:
 	pip install haas
 	haas simphony -v
 	haas jyulb -v
-	haas simlammps -v
+	LD_LIBRARY_PATH=./lib/:$LD_LIBRARY_PATH haas simlammps -v
 	haas simphony_mayavi -v
 	(cd src/simphony-openfoam; haas foam_controlwrapper -v)
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -13,21 +13,23 @@ else
 endif
 
 
-.PHONY: clean base apt-openfoam apt-simphony apt-lammps apt-numerrin apt-mayavi fix-pip simphony-env lammps jyu-lb simphony simphony-lammps simphony-numerrin simphony-mayavi simphony-openfoam simphony-jyulb test-plugins test-framework
+.PHONY: clean base apt-openfoam apt-kratos apt-simphony apt-numerrin apt-lammps apt-mayavi fix-pip simphony-env lammps jyu-lb simphony simphony-kratos simphony-lammps simphony-numerrin simphony-mayavi simphony-openfoam simphony-jyulb test-plugins test-framework
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  base              to install essential packages (requires sudo)"
 	@echo "  apt-openfoam      to install openfoam 2.2.2 (requires sudo)"
 	@echo "  apt-simphony      to install building depedencies for the simphony library (requires sudo)"
+	@echo "  apt-numerrin      to install numerrin"
+	@echo "  apt-kratos        to install kratos solver"
 	@echo "  apt-lammps        to install building depedencies for the lammps solver (requires sudo)"
-	@echo "  apt-numerrin      to install numerrin (requires sudo)"
 	@echo "  apt-mayavi        to install building depedencies for the mayavi (requires sudo)"
 	@echo "  fix-pip           to update the version of pip and virtual evn (requires sudo)"
 	@echo "  simphony-env      to create a simphony virtualenv"
 	@echo "  lammps            to build and install the lammps solver"
 	@echo "  jyu-lb            to build and install the JYU-LB solver"
 	@echo "  simphony          to build and install the simphony library"
+	@echo "  simphony-kratos   to build and install the simphony-kratos plugin"
 	@echo "  simphony-lammps   to build and install the simphony-lammps plugin"
 	@echo "  simphony-numerrin to build and install the simphony-numerrin plugin"
 	@echo "  simphony-mayavi   to build and install the simphony-mayavi plugin"
@@ -39,13 +41,11 @@ help:
 	@echo "  clean             remove any temporary folders"
 
 clean:
-	rm -Rf src/lammps
+	rm -Rf src/kratos
 	rm -Rf src/JYU-LB
 	rm -Rf src/simphony-openfoam
 	rm -Rf src/simphony-numerrin
-	rm -rf lib/liblammps.so
-	rm -rf lib/libnumerrin4.so
-	rm -rf lib/numerrin.so
+	rm -rf lib/*
 	@echo
 	@echo "Removed temporary folders"
 
@@ -67,6 +67,16 @@ apt-simphony:
 	apt-get install -y python-dev cython libhdf5-serial-dev libatlas-dev libatlas3gf-base
 	@echo
 	@echo "Build dependencies for simphony installed"
+
+apt-kratos:
+	rm -Rf src/kratos
+	mkdir -p src/kratos
+	wget https://web.cimne.upc.edu/users/croig/data/kratos-simphony.tgz -O src/kratos/kratos.tgz
+	(tar -xzf src/kratos/kratos.tgz -C src/kratos; rm -Rf src/kratos/kratos.tgz)
+	rm $(SIMPHONYENV)/lib/python2.7/site-packages/KratosMultiphysics
+	(ln -s $(PWD)/src/kratos/KratosMultiphysics $(SIMPHONYENV)/lib/python2.7/site-packages/KratosMultiphysics)
+	@echo
+	@echo "Kratos solver installed"
 
 apt-lammps:
 	apt-get update -qq
@@ -156,6 +166,11 @@ simphony-openfoam:
 	@echo
 	@echo "Simphony OpenFoam plugin installed"
 
+simphony-kratos:
+	pip install --upgrade git+https://github.com/simphony/simphony-kratos.git@0.1.1
+	@echo
+	@echo "Simphony Kratos plugin installed"
+
 simphony-jyulb:
 	pip install git+https://github.com/simphony/simphony-jyulb.git@0.1.3
 	@echo
@@ -181,6 +196,7 @@ test-plugins:
 	LD_LIBRARY_PATH=./lib/:$LD_LIBRARY_PATH haas simlammps -v
 	haas simphony_mayavi -v
 	$(TEST_NUMERRIN_COMMAND)
+	(LD_LIBRARY_PATH=./src/kratos/libs:$LD_LIBRARY_PATH haas simkratos)
 	@echo
 	@echo "Tests for the simphony plugins done"
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 
-.PHONY: clean base apt-openfoam apt-simphony apt-lammps apt-numerrin apt-mayavi fix-pip simphony-env lammps jyu-lb simphony simphony-lammps simphony-numerrin simphony-mayavi simphony-openfoam simphony-jyu-lb test-plugins test-framework
+.PHONY: clean base apt-openfoam apt-simphony apt-lammps apt-numerrin apt-mayavi fix-pip simphony-env lammps jyu-lb simphony simphony-lammps simphony-numerrin simphony-mayavi simphony-openfoam simphony-jyulb test-plugins test-framework
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -32,7 +32,7 @@ help:
 	@echo "  simphony-numerrin to build and install the simphony-numerrin plugin"
 	@echo "  simphony-mayavi   to build and install the simphony-mayavi plugin"
 	@echo "  simphony-openfoam to build and install the simphony-mayavi plugin"
-	@echo "  simphony-jyu-lb   to build and install the simphony-jyu-lb plugin"
+	@echo "  simphony-jyulb    to build and install the simphony-jyulb plugin"
 	@echo "  simphony-plugins  to build and install all the simphony-plugins"
 	@echo "  test-plugins      run the tests for all the simphony-plugins"
 	@echo "  test-framework    run the tests for the simphony-framework"
@@ -42,7 +42,6 @@ clean:
 	rm -Rf src/lammps
 	rm -Rf src/JYU-LB
 	rm -Rf src/simphony-openfoam
-	rm -Rf src/simphony-jyulb
 	rm -Rf src/simphony-numerrin
 	rm -rf lib/liblammps.so
 	rm -rf lib/libnumerrin4.so
@@ -120,7 +119,7 @@ lammps:
 
 jyu-lb:
 	rm -Rf src/JYU-LB
-	git clone --branch master https://github.com/simphony/JYU-LB.git src/JYU-LB
+	git clone --branch 0.1.2 https://github.com/simphony/JYU-LB.git src/JYU-LB
 	$(MAKE) -C src/JYU-LB -j 2
 	cp src/JYU-LB/bin/jyu_lb_isothermal.exe $(SIMPHONYENV)/bin/jyu_lb_isothermal.exe
 	rm -Rf src/JYU-LB
@@ -157,11 +156,8 @@ simphony-openfoam:
 	@echo
 	@echo "Simphony OpenFoam plugin installed"
 
-simphony-jyu-lb:
-	rm -Rf src/simphony-jyulb
-	git clone --branch 0.1.2 --depth 1 https://github.com/simphony/simphony-jyulb.git src/simphony-jyulb
-	git clone --branch master https://github.com/simphony/JYU-LB.git src/simphony-jyulb/JYU-LB
-	(cd src/simphony-jyulb; python setup.py develop)
+simphony-jyulb:
+	pip install git+https://github.com/simphony/simphony-jyulb.git@0.1.3
 	@echo
 	@echo "Simphony jyu-lb plugin installed"
 
@@ -170,7 +166,7 @@ simphony-lammps:
 	@echo
 	@echo "Simphony lammps plugin installed"
 
-simphony-plugins: simphony-mayavi simphony-openfoam simphony-jyu-lb simphony-lammps
+simphony-plugins: simphony-mayavi simphony-openfoam simphony-jyulb simphony-lammps
 	@echo
 	@echo "Simphony plugins installed"
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ help:
 
 clean:
 	rm -Rf src/kratos
-	rm -Rf src/JYU-LB
 	rm -Rf src/simphony-openfoam
 	rm -Rf src/simphony-numerrin
 	rm -rf lib/*

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ simphony-kratos:
 	@echo "Simphony Kratos plugin installed"
 
 simphony-jyulb:
-	pip install git+https://github.com/simphony/simphony-jyulb.git@0.1.3
+	pip install --upgrade git+https://github.com/simphony/simphony-jyulb.git@0.1.3
 	@echo
 	@echo "Simphony jyu-lb plugin installed"
 

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ are:
 - https://github.com/simphony/simphony-jyulb/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.2, version 0.1.2
 - https://github.com/simphony/simphony-openfoam/releases/tag/0.1.1, version 0.1.1
+- https://github.com/simphony/simphony-numerrin/releases/tag/0.1.0, version 0.1.0
 - https://github.com/simphony/simphony-mayavi/releases/tag/0.1.1, version 0.1.1
 
 
@@ -76,6 +77,7 @@ various apt repositories, and require ``sudo`` access::
   sudo apt-simphony
   sudo apt-lammps
   sudo apt-mayavi
+  sudo apt-numerrin
 
 
 .. note::
@@ -84,6 +86,10 @@ various apt repositories, and require ``sudo`` access::
    please activate the related environment::
 
      source /opt/openfoam222/etc/bashrc
+   
+   The ``apt-numerrin`` target will install nummerin library. To use this solver, please
+   ensure that environment variable PYNUMERRIN_LICENSE points to Numerrin license file.
+
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -87,8 +87,9 @@ various apt repositories, and require ``sudo`` access::
 
      source /opt/openfoam222/etc/bashrc
    
-   The ``apt-numerrin`` target will install nummerin library. To use this solver, please
-   ensure that environment variable PYNUMERRIN_LICENSE points to Numerrin license file.
+   The ``apt-numerrin`` target will install the numerrin library. To use this solver, please
+   ensure that environment variable PYNUMERRIN_LICENSE points to a valid Numerrin
+   license file.
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,6 @@ various apt repositories, and require ``sudo`` access::
   sudo apt-simphony
   sudo apt-lammps
   sudo apt-mayavi
-  sudo apt-numerrin
-  sudo apt-kratos
 
 
 .. note::
@@ -123,7 +121,7 @@ which will create a virtual enviroment in ``~/simphony`` or::
 
 .. note::
 
-   From this point the simphony enviroment needs to be active::
+   From this point the simphony environment needs to be active::
 
      source ~/simphony/bin/activate
 
@@ -136,6 +134,8 @@ To build them there are separate targets::
 
   make -j 2 lammps
   make -j 2 jyu-lb
+  make numerrin
+  make jyu-lb
 
 Install Simphony
 ~~~~~~~~~~~~~~~~
@@ -156,11 +156,10 @@ Complete script
 ::
 
   sudo make base apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
-  make apt-kratos apt-numerrin 
   source /opt/openfoam222/etc/bashrc
   make simphony-env
   source ~/simphony/bin/activate
-  make -j 2 lammps jyu-lb
+  make -j 2 kratos numerrin lammps jyu-lb
   make simphony
   make simphony-plugins
 

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,7 @@ Complete script
 
 ::
 
-  sudo make base apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
+  sudo make base apt-numerrin apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
   source /opt/openfoam222/etc/bashrc
   source ~/simphony/bin/activate
   make simphony-env
@@ -168,3 +168,7 @@ Test
 ::
 
    make test-framework
+
+.. note::
+
+   The testing simphony-numerrin is only performed if the environement variable HAVE_NUMERRIN is set to yes (i.e. ''HAVE_NUMERRIN=yes make test-framework'')

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ The SimPhoNy plugins that are compatible with this release:
 are:
 
 - https://github.com/simphony/simphony-jyulb/releases/tag/0.1.3, version 0.1.3
+- https://github.com/simphony/simphony-kratos/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.3, version 0.1.3
 - https://github.com/simphony/simphony-openfoam/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-numerrin/releases/tag/0.1.0, version 0.1.0
@@ -78,6 +79,7 @@ various apt repositories, and require ``sudo`` access::
   sudo apt-lammps
   sudo apt-mayavi
   sudo apt-numerrin
+  sudo apt-kratos
 
 
 .. note::
@@ -153,7 +155,8 @@ Complete script
 
 ::
 
-  sudo make base apt-numerrin apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
+  sudo make base apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
+  make apt-kratos apt-numerrin 
   source /opt/openfoam222/etc/bashrc
   source ~/simphony/bin/activate
   make simphony-env

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ The simphony-common version that is supported in version 0.1.3 of the framework 
 The SimPhoNy plugins that are compatible with this release:
 are:
 
-- https://github.com/simphony/simphony-jyulb/releases/tag/0.1.1, version 0.1.1
+- https://github.com/simphony/simphony-jyulb/releases/tag/0.1.3, version 0.1.3
 - https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.2, version 0.1.2
 - https://github.com/simphony/simphony-openfoam/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-numerrin/releases/tag/0.1.0, version 0.1.0

--- a/README.rst
+++ b/README.rst
@@ -158,8 +158,8 @@ Complete script
   sudo make base apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
   make apt-kratos apt-numerrin 
   source /opt/openfoam222/etc/bashrc
-  source ~/simphony/bin/activate
   make simphony-env
+  source ~/simphony/bin/activate
   make -j 2 lammps jyu-lb
   make simphony
   make simphony-plugins

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ The SimPhoNy plugins that are compatible with this release:
 are:
 
 - https://github.com/simphony/simphony-jyulb/releases/tag/0.1.3, version 0.1.3
-- https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.2, version 0.1.2
+- https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.3, version 0.1.3
 - https://github.com/simphony/simphony-openfoam/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-numerrin/releases/tag/0.1.0, version 0.1.0
 - https://github.com/simphony/simphony-mayavi/releases/tag/0.1.1, version 0.1.1

--- a/tests/test_engine_import.py
+++ b/tests/test_engine_import.py
@@ -1,13 +1,19 @@
 import unittest
 import importlib
+import os
 
 ENGINES = [
     'lammps',
     'openfoam',
     'jyulb']
 
+if os.getenv("HAVE_NUMERRIN", "no") == "yes":
+    ENGINES.append("numerrin")
+
+
 class TestEngineImport(unittest.TestCase):
 
     def test_engine_import(self):
         for engine in ENGINES:
-            importlib.import_module('simphony.engine',engine)
+    	    print engine 
+            importlib.import_module('simphony.engine', engine)

--- a/tests/test_engine_import.py
+++ b/tests/test_engine_import.py
@@ -5,6 +5,7 @@ import os
 ENGINES = [
     'lammps',
     'openfoam',
+    'kratos',
     'jyulb']
 
 if os.getenv("HAVE_NUMERRIN", "no") == "yes":
@@ -15,5 +16,4 @@ class TestEngineImport(unittest.TestCase):
 
     def test_engine_import(self):
         for engine in ENGINES:
-    	    print engine 
             importlib.import_module('simphony.engine', engine)


### PR DESCRIPTION
This PR adds the released INTERNAL wrappers to modeling engines.

 Added to Makefile | Wrapper | Comments
--- | --- | ---
 :heavy_check_mark:   | jyu-lb |  ~~workaround some of the issues in  simphony/simphony-jyulb#21. See commit message of  0012609afd52230cf2551c7dd5e49a8bf85765f5~~  
 :heavy_check_mark:  | lammps-md |  ~~had to alter LD_LIBRARY_PATH when running tests to that lammps.py could find the lammps library~~
 :heavy_check_mark: | kratos | ~~waiting for simphony/simphony-kratos#9.   **blocking issues are simphony/simphony-kratos#11 and simphony/simphony-kratos#15**.    workaround for issue simphony/simphony-kratos#14~~
 :heavy_check_mark:   | numerrin |  workarounds some of the issues (simphony/simphony-numerrin#5 and simphony/simphony-numerrin#6).  currently testing (through test-framework/test-plugins) only occurs when an environmental variable is set (HAVE_NUMERRIN=yes)
   | openfoam | waiting for simphony/simphony-openfoam#23
