### PR TITLE
Upgrade openfoam to version 0.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - sudo make base apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
 install:
-  - source /opt/openfoam222/etc/bashrc
   - make simphony-env
   - make -j 2 lammps jyu-lb numerrin
   - source ~/simphony/bin/activate
+  - source /opt/openfoam222/etc/bashrc
   - make simphony
   - make simphony-plugins
 script:

--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,7 @@ test-plugins:
 	haas jyulb -v
 	haas simlammps -v
 	haas simphony_mayavi -v
+	(cd src/simphony-openfoam; haas foam_controlwrapper foam_internalwrapper -v)
 	haas simkratos -v
 	$(TEST_NUMERRIN_COMMAND)
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ help:
 	@echo "  simphony-lammps   to build and install the simphony-lammps plugin"
 	@echo "  simphony-numerrin to build and install the simphony-numerrin plugin"
 	@echo "  simphony-mayavi   to build and install the simphony-mayavi plugin"
-	@echo "  simphony-openfoam to build and install the simphony-mayavi plugin"
+	@echo "  simphony-openfoam to build and install the simphony-openfoam plugin"
 	@echo "  simphony-jyu-lb   to build and install the simphony-jyu-lb plugin"
 	@echo "  simphony-plugins  to build and install all the simphony-plugins"
 	@echo "  test-plugins      run the tests for all the simphony-plugins"
@@ -165,9 +165,7 @@ simphony-numerrin:
 simphony-openfoam:
 	pip install --upgrade svn+https://svn.code.sf.net/p/openfoam-extend/svn/trunk/Breeder/other/scripting/PyFoam#egg=PyFoam
 	rm -Rf src/simphony-openfoam
-	git clone --branch 0.1.1 --depth 1 https://github.com/simphony/simphony-openfoam.git src/simphony-openfoam
-	/opt/openfoam222/wmake/wmake libso src/simphony-openfoam/openfoam-interface
-	(cd src/simphony-openfoam/openfoam-interface; python setup.py install)
+	git clone --branch 0.1.3 --depth 1 https://github.com/simphony/simphony-openfoam.git src/simphony-openfoam
 	(cd src/simphony-openfoam; python setup.py install)
 	@echo
 	@echo "Simphony OpenFoam plugin installed"

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,10 @@ simphony-numerrin:
 	@echo "Simphony Numerrin plugin installed"
 
 simphony-openfoam:
-	pip install --upgrade svn+https://svn.code.sf.net/p/openfoam-extend/svn/trunk/Breeder/other/scripting/PyFoam#egg=PyFoam
 	rm -Rf src/simphony-openfoam
+	(mkdir -p src/simphony-openfoam/pyfoam; wget https://openfoamwiki.net/images/3/3b/PyFoam-0.6.4.tar.gz -O src/simphony-openfoam/pyfoam/pyfoam.tgz --no-check-certificate)
+	tar -xzf src/simphony-openfoam/pyfoam/pyfoam.tgz -C src/simphony-openfoam/pyfoam
+	(pip install --upgrade src/simphony-openfoam/pyfoam/PyFoam-0.6.4; rm -Rf src/simphony-openfoam/pyfoam)
 	git clone --branch 0.1.3 --depth 1 https://github.com/simphony/simphony-openfoam.git src/simphony-openfoam
 	(cd src/simphony-openfoam; python setup.py install)
 	@echo

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ are:
 - https://github.com/simphony/simphony-jyulb/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-kratos/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.2, version 0.1.2
-- https://github.com/simphony/simphony-openfoam/releases/tag/0.1.1, version 0.1.1
+- https://github.com/simphony/simphony-openfoam/releases/tag/0.1.3, version 0.1.3
 - https://github.com/simphony/simphony-numerrin/releases/tag/0.1.0, version 0.1.0
 - https://github.com/simphony/simphony-mayavi/releases/tag/0.1.1, version 0.1.1
 


### PR DESCRIPTION
This PR does the following:
* uses the latest released version of the openfoam wrappers
* reactivates the testing of the openfoam wrappers
* installs PyFoam (0.6.4)