### PR TITLE
Fix simphony-lammps version (0.1.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ simphony-jyu-lb:
 	@echo "Simphony jyu-lb plugin installed"
 
 simphony-lammps:
-	pip install --upgrade git+https://github.com/simphony/simphony-lammps-md.git@0.1.2#egg=simlammps
+	pip install --upgrade git+https://github.com/simphony/simphony-lammps-md.git@0.1.3#egg=simlammps
 	@echo
 	@echo "Simphony lammps plugin installed"
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ The simphony-common version that is supported in version 0.1.3 of the framework 
 The SimPhoNy plugins that are compatible with this release:
 are:
 
-- https://github.com/simphony/simphony-jyulb/releases/tag/0.1.1, version 0.1.1
+- https://github.com/simphony/simphony-jyulb/releases/tag/0.1.3, version 0.1.3
 - https://github.com/simphony/simphony-kratos/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.3, version 0.1.3
 - https://github.com/simphony/simphony-openfoam/releases/tag/0.1.3, version 0.1.3

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ are:
 
 - https://github.com/simphony/simphony-jyulb/releases/tag/0.1.1, version 0.1.1
 - https://github.com/simphony/simphony-kratos/releases/tag/0.1.1, version 0.1.1
-- https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.2, version 0.1.2
+- https://github.com/simphony/simphony-lammps-md/releases/tag/0.1.3, version 0.1.3
 - https://github.com/simphony/simphony-openfoam/releases/tag/0.1.3, version 0.1.3
 - https://github.com/simphony/simphony-numerrin/releases/tag/0.1.0, version 0.1.0
 - https://github.com/simphony/simphony-mayavi/releases/tag/0.1.1, version 0.1.1


### PR DESCRIPTION
* uses simphony-lammps 0.1.3 (it was missing from PR #37) 
* fixes simphony-jyulb version in README