### PR TITLE
Time build components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - sudo make base apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
 install:
   - make simphony-env
-  - make -j 3 kratos lammps jyu-lb numerrin
+  - make kratos lammps jyu-lb numerrin
   - source ~/simphony/bin/activate
   - source /opt/openfoam222/etc/bashrc
   - make simphony

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ before_install:
   - sudo make base apt-openfoam apt-simphony apt-lammps apt-mayavi fix-pip
 install:
   - make simphony-env
-  - make kratos lammps jyu-lb numerrin
+  - make kratos
+  - make lammps
+  - make jyu-lb
+  - make numerrin
   - source ~/simphony/bin/activate
   - source /opt/openfoam222/etc/bashrc
   - make simphony

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - source ~/simphony/bin/activate
   - source /opt/openfoam222/etc/bashrc
   - make simphony
-  - make simphony-jyulb
+  - make simphony-jyu-lb
   - make simphony-lammps
   - make simphony-mayavi
   - make simphony-openfoam

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   - make simphony-lammps
   - make simphony-mayavi
   - make simphony-openfoam
+  - make simphony-numerrin
   - make simphony-kratos
 script:
   - make $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ install:
   - source ~/simphony/bin/activate
   - source /opt/openfoam222/etc/bashrc
   - make simphony
-  - make jyulb
-  - make lammps
-  - make mayavi
-  - make openfoam
-  - make kratos
+  - make simphony-jyulb
+  - make simphony-lammps
+  - make simphony-mayavi
+  - make simphony-openfoam
+  - make simphony-kratos
 script:
   - make $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ install:
   - source ~/simphony/bin/activate
   - source /opt/openfoam222/etc/bashrc
   - make simphony
-  - make simphony-plugins
+  - make jyulb
+  - make lammps
+  - make mayavi
+  - make openfoam
+  - make kratos
 script:
   - make $TEST_SUITE

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ apt-openfoam:
 
 apt-simphony:
 	add-apt-repository ppa:cython-dev/master-ppa -y
+	add-apt-repository ppa:cython-dev/master-ppa -y
 	apt-get update -qq
 	apt-get install -y python-dev cython libhdf5-serial-dev libatlas-dev libatlas3gf-base
 	@echo
@@ -110,11 +111,11 @@ lammps:
 	rm -Rf src/lammps
 	# bulding and installing executable
 	git clone --branch r12824 --depth 1 git://git.lammps.org/lammps-ro.git src/lammps
-	$(MAKE) -C src/lammps/src ubuntu_simple -j 2
+	$(MAKE) -C src/lammps/src ubuntu_simple -j 3
 	cp src/lammps/src/lmp_ubuntu_simple $(SIMPHONYENV)/bin/lammps
 	# bulding and installing python module
-	$(MAKE) -C src/lammps/src makeshlib -j 2
-	$(MAKE) -C src/lammps/src ubuntu_simple -f Makefile.shlib -j 2
+	$(MAKE) -C src/lammps/src makeshlib -j 3
+	$(MAKE) -C src/lammps/src ubuntu_simple -f Makefile.shlib -j 3
 	(cd src/lammps/python; python install.py $(SIMPHONYENV)/lib $(SIMPHONYENV)/lib/python2.7/site-packages/)
 	rm -Rf src/lammps
 	@echo


### PR DESCRIPTION
This changes travis.yml so that we can have a better idea on what it taking to much time.

It looks that the problematic items are:

- make lammps
- make simphony
- make simphony-openfoam
- make test-kratos
