### PR TITLE
update pip 8.0.0 and its complication on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - sudo make base
   - sudo make apt-openfoam-deps apt-simphony-deps apt-lammps-deps apt-mayavi-deps apt-aviz-deps
-  - sudo make fix-system-python
+  - make fix-system-python
 install:
   - make simphony-env
   - make aviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - sudo make base
   - sudo make apt-openfoam-deps apt-simphony-deps apt-lammps-deps apt-mayavi-deps apt-aviz-deps
-  - make fix-system-python
+  - make fix-pip
 install:
   - make simphony-env
   - make aviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ virtualenv:
 env:
   global:
   - SIMPHONYENV=~/simphony
-  matrix:
-  - TEST_SUITE="test-framework"
-  - TEST_SUITE="test-jyulb test-lammps test-openfoam test-kratos"
 before_install:
   - sudo apt-get install ccache
   - ccache -s
@@ -38,4 +35,4 @@ install:
   - make simphony-kratos
   - make fix-simopenfoam
 script:
-  - make ${TEST_SUITE}
+  - make test-framework

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - sudo make base
   - sudo make apt-openfoam-deps apt-simphony-deps apt-lammps-deps apt-mayavi-deps apt-aviz-deps
-  - make fix-pip
-  - sudo pip uninstall -y argparse
-  - sudo pip install argparse
-  - sudo pip uninstall -y pyyaml
-  - sudo pip install pyyaml
+  - sudo make fix-system-python
 install:
   - make simphony-env
   - make aviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ before_install:
   - sudo make base
   - sudo make apt-openfoam-deps apt-simphony-deps apt-lammps-deps apt-mayavi-deps apt-aviz-deps
   - make fix-pip
-  - pip install --allow-external PIL --allow-unverified PIL PIL
+  - sudo pip uninstall -y argparse
+  - sudo pip install argparse
+  - sudo pip uninstall -y pyyaml
+  - sudo pip install pyyaml
 install:
   - make simphony-env
   - make aviz

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
 endif
 
 
-.PHONY: clean base apt-aviz-deps apt-openfoam-deps apt-simphony-deps apt-lammps-deps apt-mayavi-deps fix-pip fix-simopenfoam simphony-env aviz lammps jyu-lb kratos numerrin simphony simphony-aviz simphony-lammps simphony-mayavi simphony-openfoam simphony-kratos simphony-jyu-lb simphony-numerrin test-plugins test-framework test-simphony test-aviz test-jyulb test-lammps test-mayavi test-openfoam test-kratos test-integration
+.PHONY: clean base apt-aviz-deps apt-openfoam-deps apt-simphony-deps apt-lammps-deps apt-mayavi-deps fix-system-python fix-simopenfoam simphony-env aviz lammps jyu-lb kratos numerrin simphony simphony-aviz simphony-lammps simphony-mayavi simphony-openfoam simphony-kratos simphony-jyu-lb simphony-numerrin test-plugins test-framework test-simphony test-aviz test-jyulb test-lammps test-mayavi test-openfoam test-kratos test-integration
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -37,7 +37,7 @@ help:
 	@echo "  apt-simphony-deps   to install building depedencies for the simphony library (requires sudo)"
 	@echo "  apt-lammps-deps     to install building depedencies for the lammps solver (requires sudo)"
 	@echo "  apt-mayavi-deps     to install building depedencies for the mayavi (requires sudo)"
-	@echo "  fix-pip             to update the version of pip and virtual evn (requires sudo)"
+	@echo "  fix-system-python   to update the version of pip, virtual evn and argparse (requires sudo)"
 	@echo "  fix-simopenfoam     to install enum3.4==1.0.4 for simphony-openfoam-0.1.5"
 	@echo "  simphony-env        to create a simphony virtualenv"
 	@echo "  aviz                to install AViz"
@@ -119,15 +119,17 @@ fix-simopenfoam:
 	@echo
 	@echo "Fixed simphony-openfoam"
 
-fix-pip:
+fix-system-python:
 	wget https://bootstrap.pypa.io/get-pip.py
 	python get-pip.py
 	rm get-pip.py
 	pip install --upgrade setuptools
 	pip install --upgrade virtualenv
+	pip install --upgrade argparse
 	@echo
 	pip --version
-	@echo "Latest pip installed"
+	pip show argparse
+	@echo "Latest pip and argparse installed"
 
 simphony-env:
 	rm -rf $(SIMPHONYENV)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
 endif
 
 
-.PHONY: clean base apt-aviz-deps apt-openfoam-deps apt-simphony-deps apt-lammps-deps apt-mayavi-deps fix-system-python fix-simopenfoam simphony-env aviz lammps jyu-lb kratos numerrin simphony simphony-aviz simphony-lammps simphony-mayavi simphony-openfoam simphony-kratos simphony-jyu-lb simphony-numerrin test-plugins test-framework test-simphony test-aviz test-jyulb test-lammps test-mayavi test-openfoam test-kratos test-integration
+.PHONY: clean base apt-aviz-deps apt-openfoam-deps apt-simphony-deps apt-lammps-deps apt-mayavi-deps fix-pip fix-simopenfoam simphony-env aviz lammps jyu-lb kratos numerrin simphony simphony-aviz simphony-lammps simphony-mayavi simphony-openfoam simphony-kratos simphony-jyu-lb simphony-numerrin test-plugins test-framework test-simphony test-aviz test-jyulb test-lammps test-mayavi test-openfoam test-kratos test-integration
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -37,7 +37,7 @@ help:
 	@echo "  apt-simphony-deps   to install building depedencies for the simphony library (requires sudo)"
 	@echo "  apt-lammps-deps     to install building depedencies for the lammps solver (requires sudo)"
 	@echo "  apt-mayavi-deps     to install building depedencies for the mayavi (requires sudo)"
-	@echo "  fix-system-python   to update the version of pip, virtual evn and argparse (requires sudo)"
+	@echo "  fix-pip             to update the version of pip, virtual evn (requires sudo)"
 	@echo "  fix-simopenfoam     to install enum3.4==1.0.4 for simphony-openfoam-0.1.5"
 	@echo "  simphony-env        to create a simphony virtualenv"
 	@echo "  aviz                to install AViz"
@@ -119,17 +119,15 @@ fix-simopenfoam:
 	@echo
 	@echo "Fixed simphony-openfoam"
 
-fix-system-python:
+fix-pip:
 	wget https://bootstrap.pypa.io/get-pip.py
 	python get-pip.py
 	rm get-pip.py
 	pip install --upgrade setuptools
 	pip install --upgrade virtualenv
-	pip install --upgrade argparse
 	@echo
 	pip --version
-	pip show argparse
-	@echo "Latest pip and argparse installed"
+	@echo "Latest pip installed"
 
 simphony-env:
 	rm -rf $(SIMPHONYENV)

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ simphony-plugins: simphony-kratos simphony-numerrin simphony-mayavi simphony-ope
 	@echo
 	@echo "Simphony plugins installed"
 
-simphony-framework: simphony simphony-plugins
+simphony-framework:
 	@echo
 	@echo "Simphony framework installed"
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 	@echo "  apt-simphony-deps   to install building depedencies for the simphony library (requires sudo)"
 	@echo "  apt-lammps-deps     to install building depedencies for the lammps solver (requires sudo)"
 	@echo "  apt-mayavi-deps     to install building depedencies for the mayavi (requires sudo)"
-	@echo "  fix-pip             to update the version of pip, virtual evn (requires sudo)"
+	@echo "  fix-pip             to update the version of pip and virtual evn (requires sudo)"
 	@echo "  fix-simopenfoam     to install enum3.4==1.0.4 for simphony-openfoam-0.1.5"
 	@echo "  simphony-env        to create a simphony virtualenv"
 	@echo "  aviz                to install AViz"

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ fix-simopenfoam:
 	@echo "Fixed simphony-openfoam"
 
 fix-pip:
-	wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+	wget https://bootstrap.pypa.io/get-pip.py
 	python get-pip.py
 	rm get-pip.py
 	pip install --upgrade setuptools
@@ -244,7 +244,7 @@ simphony-plugins: simphony-kratos simphony-numerrin simphony-mayavi simphony-ope
 	@echo
 	@echo "Simphony plugins installed"
 
-simphony-framework:
+simphony-framework: simphony simphony-plugins
 	@echo
 	@echo "Simphony framework installed"
 


### PR DESCRIPTION
pip is upgraded to 8.0.0 and the link to get-pip.py needs to be updated.

The site packages ``argparse`` and ``pyyaml`` on Travis are installed by distutils and the new pip refuses to upgrade them.  So I uninstall and reinstall them using ``sudo pip``, which would load the site's 7.1.2 ``pip`` instead of the installed 8.0.0 one.

If you wonder why not just use pip 7.1.2 for everything at the very beginning, I tried, but it won't concede: https://travis-ci.org/simphony/simphony-framework/jobs/103801474
