### PR TITLE
remove 'simphony-framework' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,10 +244,6 @@ simphony-plugins: simphony-kratos simphony-numerrin simphony-mayavi simphony-ope
 	@echo
 	@echo "Simphony plugins installed"
 
-simphony-framework: simphony simphony-plugins
-	@echo
-	@echo "Simphony framework installed"
-
 test-plugins: test-simphony test-jyulb test-lammps test-mayavi test-openfoam test-kratos test-aviz
 	@echo
 	@echo "Tests for simphony plugins done"

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ simphony-plugins: simphony-kratos simphony-numerrin simphony-mayavi simphony-ope
 	@echo
 	@echo "Simphony plugins installed"
 
-simphony-framework:
+simphony-framework: simphony simphony-plugins
 	@echo
 	@echo "Simphony framework installed"
 


### PR DESCRIPTION
Maybe a bit misleading to print "simphony framework installed" when nothing is done.
Proposal 1:  install the whole lot, i.e. simphony and simphony-plugins (to be consistent with test-framework)
Proposal 2:  remove simphony-framework target altogether
