### PR TITLE
Trusty support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ matrix:
   include:
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
-    - dist: trusty
-      env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
-    - dist: trusty
-      env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
-  allow_failures:
-    - env: 
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ matrix:
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
 # Workaround for bogus additional job (travis-ci#4681)
   exclude:
-    - os: linux
+    - language: python
+
 cache:
   pip: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,26 @@ python:
   - "2.7"
 virtualenv:
   system_site_packages: true
-os: linux
-env:
-  global:
-  - SIMPHONYENV=~/simphony
-  matrix:
-  - TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
-  - TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
+
 matrix:
   include:
-    - dist: precise
-    - dist: trusty
+    - os: linux
+      sudo: required
+      dist: precise
+      env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
+    - os: linux
+      sudo: required
+      dist: precise
+      env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
+    - os: linux
+      sudo: required
+      dist: trusty
+      env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
+    - os: linux
+      sudo: required
+      dist: trusty
+      env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
+
 cache:
   pip: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
       dist: trusty
       python: 2.7
-  allow_failure:
+  allow_failures:
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
       dist: trusty
       python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ python:
   - "2.7"
 virtualenv:
   system_site_packages: true
+os: linux
 env:
   global:
   - SIMPHONYENV=~/simphony
   matrix:
   - TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
   - TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
+matrix:
+  include:
+    - dist: precise
+    - dist: trusty
 cache:
   pip: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ matrix:
       sudo: required
       dist: trusty
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
-
+# Workaround for bogus additional job (travis-ci#4681)
+  exclude:
+    - env: 
 cache:
   pip: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,19 @@ matrix:
       sudo: required
       dist: trusty
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
-# Workaround for bogus additional job (travis-ci#4681)
-  exclude:
-    - language: python
+  allow_failures:
+    - os: linux
+      sudo: required
+      dist: precise
+      env: 
 
 cache:
   pip: true
   directories:
   - $HOME/.ccache
 before_install:
+# Workaround for bogus additional job (travis-ci#4681). Proposed solutions didn't work
+  - if [ ! ${SIMPHONYENV} ]; then false; fi;
   - sudo apt-get update -qq
   - sudo apt-get install ccache
   - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
-python:
-  - "2.7"
 virtualenv:
   system_site_packages: true
 
 matrix:
   include:
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
+      python: 2.7
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
+      python: 2.7
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ matrix:
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
       dist: trusty
       python: 2.7
-    - env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
-      dist: trusty
-      python: 2.7
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,18 @@ matrix:
       python: 2.7
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
       python: 2.7
+    - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
+      dist: trusty
+      python: 2.7
+    - env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
+      dist: trusty
+      python: 2.7
 
 cache:
   pip: true
   directories:
   - $HOME/.ccache
 before_install:
-# Workaround for bogus additional job (travis-ci#4681). Proposed solutions didn't work
-  - if [ ! ${SIMPHONYENV} ]; then false; fi;
   - sudo apt-get update -qq
   - sudo apt-get install ccache
   - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
       dist: trusty
       python: 2.7
+  allow_failure:
+    - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
+      dist: trusty
+      python: 2.7
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,17 @@ virtualenv:
 matrix:
   include:
     - os: linux
-      sudo: required
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
     - os: linux
-      sudo: required
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
     - os: linux
-      sudo: required
       dist: trusty
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
     - os: linux
-      sudo: required
       dist: trusty
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
   allow_failures:
     - os: linux
-      sudo: required
-      dist: precise
       env: 
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,9 @@ matrix:
   include:
     - os: linux
       sudo: required
-      dist: precise
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
     - os: linux
       sudo: required
-      dist: precise
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
     - os: linux
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
 # Workaround for bogus additional job (travis-ci#4681)
   exclude:
-    - env: 
+    - os: linux
 cache:
   pip: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,14 @@ virtualenv:
 
 matrix:
   include:
-    - os: linux
+    - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
+    - env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
+    - dist: trusty
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
-    - os: linux
-      env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
-    - os: linux
-      dist: trusty
-      env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
-    - os: linux
-      dist: trusty
+    - dist: trusty
       env: SIMPHONYENV=~/simphony TEST_SUITE=test-paraview DEPS=apt-paraview-deps PLUGINS=simphony-paraview
   allow_failures:
-    - os: linux
-      env: 
+    - env: 
 
 cache:
   pip: true


### PR DESCRIPTION
Introduces build on trusty so that we can satisfy both the 12.04 build (for general builds on travis) and the 14.04 build (for simphony-remote-docker)