### PR TITLE
Removes the openfoam link that we don't need anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,6 @@ else
 endif
 	apt-get update -qq
 	apt-get install -y --force-yes openfoam$(OPENFOAM_VERSION)
-	ln -s /opt/openfoam$(OPENFOAM_VERSION) /opt/openfoam
 	@echo
 	@echo "Openfoam installed use . /opt/openfoam$(OPENFOAM_VERSION)/etc/bashrc to setup the environment"
 


### PR DESCRIPTION
We used this link for the .travis.yml to work against any version of openfoam. Now it's no longer needed because it's installed in the activation script.