### PR TITLE
Remove allow_failures for trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ matrix:
     - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
       dist: trusty
       python: 2.7
-  allow_failures:
-    - env: SIMPHONYENV=~/simphony TEST_SUITE=test-framework DEPS=apt-mayavi-deps PLUGINS=simphony-mayavi
-      dist: trusty
-      python: 2.7
 
 cache:
   pip: true

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,6 @@ else
 endif
 	apt-get update -qq
 	apt-get install -y --force-yes openfoam$(OPENFOAM_VERSION)
-	ln -s /opt/openfoam$(OPENFOAM_VERSION) /opt/openfoam
 	@echo
 	@echo "Openfoam installed use . /opt/openfoam$(OPENFOAM_VERSION)/etc/bashrc to setup the environment"
 


### PR DESCRIPTION
Removes the allow_failures entry for trusty. It is now green and we want it to be so from now on.
