### PR TITLE
Fixes default variable that does not expand tilde in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Simphony Framework
 # You can set these variables from the command line.
-SIMPHONYENV   ?= ~/simphony
+SIMPHONYENV   ?= $(HOME)/simphony
 # end 
 
 UBUNTU_CODENAME=$(shell lsb_release -cs)


### PR DESCRIPTION
Tilde is not expanded in Makefiles. The default value was not going to work.
