### PR TITLE
Installing software-properties-common for apt-add-repository on trusty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,9 @@ base:
 	add-apt-repository ppa:git-core/ppa -y
 	apt-get update -qq
 	apt-get install build-essential git subversion -y
+ifeq ($(UBUNTU_CODENAME),trusty)
+	apt-get install software-properties-common
+endif
 
 apt-aviz-deps:
 	apt-get install -y python-qt4 python-qt4-gl qt4-qmake qt4-dev-tools libpng-dev libqt4-dev


### PR DESCRIPTION
Docker images are missing add-apt-repo, so we preemptively install it on the makefile for trusty (where we need it)