### PR TITLE
Moved lammps git to http after git connection issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ aviz:
 lammps:
 	rm -Rf src/lammps
 	# bulding and installing executable
-	git clone --branch $(LAMMPS_VERSION) --depth 1 git://git.lammps.org/lammps-ro.git src/lammps
+	git clone --branch $(LAMMPS_VERSION) http://git.lammps.org/lammps-ro.git src/lammps
 	$(MAKE) -C src/lammps/src ubuntu_simple -j 3
 	cp src/lammps/src/lmp_ubuntu_simple $(SIMPHONYENV)/bin/lammps
 	# bulding and installing python module


### PR DESCRIPTION
git lammps is inaccessible since 24 hours. http seems to be doing ok. Moving the checkout to http.